### PR TITLE
Switch to react-pdf viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "react-toastify": "^11.0.5",
-    "web-vitals": "^2.1.4",
-    "pdf-viewer-reactjs": "^2.2.3"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -134,12 +134,11 @@ describe("PDF Signing App - Basic Tests", () => {
 
     expect(await screen.findByText(/Uploading file/i)).toBeInTheDocument();
 
-    // Wait for signing completion (loader disappears and signed iframe appears)
+    // Wait for signing completion (loader disappears and PDF pages render)
     await waitFor(() => {
       expect(screen.queryByText(/Uploading file/i)).not.toBeInTheDocument();
+      expect(screen.getAllByTestId('pdf-page').length).toBeGreaterThan(0);
     });
-
-    expect(screen.getByTitle(/Signed PDF/i)).toBeInTheDocument();
 
     // Clean up mock fetch
     global.fetch.mockRestore();

--- a/src/components/PdfPreview.js
+++ b/src/components/PdfPreview.js
@@ -1,16 +1,23 @@
-import PDFViewer from 'pdf-viewer-reactjs';
+import React, { useState } from 'react';
+import { Document, Page } from 'react-pdf';
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/Page/TextLayer.css';
 
 function PdfPreview({ url }) {
+  const [numPages, setNumPages] = useState(null);
+
+  const onLoadSuccess = ({ numPages }) => {
+    setNumPages(numPages);
+  };
+
   return (
-    <PDFViewer
-      document={{
-        url: url // This can be a Blob URL or a remote URL
-      }}
-      hideZoom={true}
-      hideRotation={true}
-      hideNavbar={false}
-      css="custom-pdf-viewer"
-    />
+    <div className="pdf-viewer">
+      <Document file={url} onLoadSuccess={onLoadSuccess} data-testid="pdf-document">
+        {Array.from(new Array(numPages), (el, index) => (
+          <Page key={`page_${index + 1}`} pageNumber={index + 1} data-testid="pdf-page" />
+        ))}
+      </Document>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- drop `pdf-viewer-reactjs` dependency
- implement a PDF previewer using `react-pdf`
- keep `MainPage` API the same
- adjust tests to look for rendered pages