### PR TITLE
Set pdfjs worker path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## PDF.js Worker
+
+This app uses [`react-pdf`](https://github.com/wojtekmaj/react-pdf) to render PDF
+documents. The project ships with a local `pdf.worker.min.js` located in the
+`public/` folder. The worker must be loaded by `pdfjs` at runtime:
+
+```javascript
+import { pdfjs } from 'react-pdf';
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
+```
+
+This initialization is performed both in `src/index.js` and `src/setupTests.js`
+so the worker is used during development, production and when running tests.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { pdfjs } from 'react-pdf';
+
+// Use the pdf.js worker shipped in the public folder
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { pdfjs } from 'react-pdf';
+
+// Jest needs the worker path defined for react-pdf components
+pdfjs.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js';


### PR DESCRIPTION
## Summary
- set up `react-pdf` worker path in `index.js`
- make tests use the same worker in `setupTests.js`
- document local `pdf.worker.min.js` usage in README